### PR TITLE
Adiciona suporte a múltiplos provedores de LLMs e alguns dos seus modelos principais 🚀

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__
 core/__pycache__/*
 core/.pytest_cache/*
 env_ai/*
@@ -5,3 +6,5 @@ __pycache__/*
 env_teste/
 notebooks/
 tests/__pycache__/
+venv
+.env

--- a/core/chat_api/__init__.py
+++ b/core/chat_api/__init__.py
@@ -1,5 +1,5 @@
 import requests
-from provedores import *
+from core.chat_api.provedores import *
 
 provedores_suportados = {
     OpenAI.placeholer(): {
@@ -18,6 +18,7 @@ provedores_suportados = {
 
 class ChatAPI:
     def __init__(self, provedor="", modelo="", api_key=""):
+        print("chat iniciado com o provedor", provedor)
         if(provedor not in provedores_suportados.keys()):
             raise UnsupportedProviderError(provedor)
 
@@ -28,6 +29,11 @@ class ChatAPI:
         self.api_url = provedores_suportados[provedor]["api_url"]
         self.modelo = modelo
         self.api_key = api_key
+
+    
+    def ajusta_retorno(self, conteudo):
+        if("```json" in conteudo):
+            return conteudo.replace("```json", "").replace("```", "")
 
     def gera_conteudo(self, contexto, prompt):
         url = self.api_url
@@ -69,12 +75,12 @@ class ChatAPI:
                 candidates = data["candidates"]
                 content = candidates[0]["content"]
                 parts = content["parts"][0]
-                return parts["text"]
+                return self.ajusta_retorno(parts["text"])
             else:
                 choices = data["choices"][0]
                 message = choices["message"]
                 content = message["content"]
-                return content
+                return self.ajusta_retorno(content)
 
         elif(resp.status_code == 400):
             print(resp.text)

--- a/core/chat_api/__init__.py
+++ b/core/chat_api/__init__.py
@@ -1,0 +1,86 @@
+import requests
+from provedores import *
+
+provedores_suportados = {
+    OpenAI.placeholer(): {
+        "modelos": OpenAI.modelos(),
+        "api_url": "https://api.openai.com/v1/chat/completions"
+    },
+    Gemini.placeholer(): {
+        "modelos": Gemini.modelos(),
+        "api_url": "https://generativelanguage.googleapis.com/v1beta/models"
+    },
+    DeepSeek.placeholer(): {
+        "modelos": DeepSeek.modelos(),
+        "api_url": "https://api.deepseek.com/chat/completions"
+    }
+}
+
+class ChatAPI:
+    def __init__(self, provedor="", modelo="", api_key=""):
+        if(provedor not in provedores_suportados.keys()):
+            raise UnsupportedProviderError(provedor)
+
+        if(modelo not in provedores_suportados[provedor]["modelos"]):
+            raise UnsupportedProviderModelError(provedor, modelo)
+
+        self.provedor = provedor
+        self.api_url = provedores_suportados[provedor]["api_url"]
+        self.modelo = modelo
+        self.api_key = api_key
+
+    def gera_conteudo(self, contexto, prompt):
+        url = self.api_url
+        headers = {
+            "Content-Type": "application/json"
+        }
+
+        payload = {}
+
+        if(self.provedor == "gemini"):
+            url = f'{self.api_url}/{self.modelo}:generateContent?key={self.api_key}'
+            payload = {
+                "contents": [
+                    {
+                        "role": "model",
+                        "parts": [{"text": contexto}]
+                    },
+                    {
+                        "role": "user",
+                        "parts": [{"text": prompt}]
+                    }
+                ]
+            }
+        else:
+            headers["Authorization"] = f'Bearer {self.api_key}'
+            payload = {
+                "model": self.modelo,
+                "messages": [
+                    {"role": "system", "content": contexto},
+                    {"role": "user", "content": prompt},
+                ]
+            }
+
+        resp = requests.post(url, headers=headers, json=payload)
+
+        if(resp.status_code == 200):
+            data = resp.json()
+            if(self.provedor == "gemini"):
+                candidates = data["candidates"]
+                content = candidates[0]["content"]
+                parts = content["parts"][0]
+                return parts["text"]
+            else:
+                choices = data["choices"][0]
+                message = choices["message"]
+                content = message["content"]
+                return content
+
+        elif(resp.status_code == 400):
+            print(resp.text)
+        elif(resp.status_code == 401):
+            print(resp.text)
+        else:
+            print(resp.url)
+            print(resp.status_code)
+            print(resp.text)

--- a/core/chat_api/provedores/__init__.py
+++ b/core/chat_api/provedores/__init__.py
@@ -1,0 +1,59 @@
+
+
+class Gemini:
+    def __init__(self, API_KEY=""):
+        ...
+
+    @staticmethod
+    def placeholer():
+        return "gemini"
+
+    @staticmethod
+    def modelos():
+        # https://ai.google.dev/gemini-api/docs/models/gemini?hl=pt-br
+        return ["gemini-2.0-flash", "gemini-2.0-flash-lite", "gemini-1.5-flash", "gemini-1.5-flash-8b", "gemini-1.5-pro"]
+
+class OpenAI:
+    def __init__(self, API_KEY=""):
+        ...
+
+    @staticmethod
+    def placeholer():
+        return "openai"
+
+    @staticmethod
+    def modelos():
+        # https://platform.openai.com/docs/models#models-overview
+        return ["gpt-4o", "gpt-4o-mini", "o1", "o3-mini", "gpt-4-turbo", "gpt-3.5-turbo"]
+
+class DeepSeek:
+    def __init__(self, API_KEY=""):
+        ...
+
+    @staticmethod
+    def placeholer():
+        return "deepseek"
+
+    @staticmethod
+    def modelos():
+        # https://api-docs.deepseek.com/quick_start/pricing
+        return ["deepseek-chat"]
+
+class UnsupportedProviderError(Exception):
+    """
+        -
+    """
+    def __init__(self, provider, message="Provedor não suportado ou não implementado."):
+        self.provider = provider
+        self.message = f"{message} Provedor fornecido: '{provider}'."
+        super().__init__(self.message)
+
+class UnsupportedProviderModelError(Exception):
+    """
+        -
+    """
+    def __init__(self, provider, model, message="Modelo não suportado ou não implementado"):
+        self.provider = provider
+        self.model = model
+        self.message = f"{message} O modelo '{model}' não está disponível para o provedor '{provider}'"
+        super().__init__(self.message)

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,12 +1,16 @@
 """Constants for the project"""
+from decouple import config
 
 NEWS_PATH = "source/rss_source.json"
 
 NUM_NOTICIAS = 3
 SIM_THRESHOLD = 0.7
-PROVIDER = "openai"
-MODEL1 = "gpt-4o-mini"
-MODEL2 = "gpt-4o"
+
+PROVIDER = config("PROVIDER")
+PROVIDER_API_KEY = config("PROVIDER_API_KEY")
+MODEL1 = config("MODEL1")
+MODEL2 = config("MODEL2")
+
 GUARDRAIL_MSG = "Tema inapropriado: %s"
 # disable linting for the next line
 # pylint: disable=line-too-long

--- a/core/guardrails.py
+++ b/core/guardrails.py
@@ -7,7 +7,7 @@ import logging
 
 from sentence_transformers import SentenceTransformer, util
 
-from core.constants import (GUARDRAIL_MSG, MODEL2, PROVIDER, SIM_THRESHOLD,
+from core.constants import (GUARDRAIL_MSG, MODEL2, PROVIDER, PROVIDER_API_KEY, SIM_THRESHOLD,
                             termos_inapropriados)
 from core.preprocessamento import remover_acentos
 from core.servico_llm import make_llm_call
@@ -100,7 +100,7 @@ def checar_tema_enem_por_llm(tema):
     # Usa um modelo mais poderoso para validar o tema
     # Escala de modelos: gpt-4o-mini < gpt-4o
     logger.info("Validando tema com modelo mais poderoso...")
-    response = make_llm_call(PROVIDER, MODEL2, contexto, prompt)
+    response = make_llm_call(PROVIDER, MODEL2, contexto, prompt, PROVIDER_API_KEY)
     response = json.loads(response)
     if "sim" in response['resposta']:
         return True

--- a/core/news.py
+++ b/core/news.py
@@ -6,7 +6,7 @@ import random
 import feedparser
 
 from core.constants import (temas_enem, NUM_NOTICIAS,
-                            PROVIDER, MODEL1)
+                            PROVIDER, PROVIDER_API_KEY, MODEL1)
 from core.guardrails import (checar_tema_enem_analise_sintatica,
                              checar_tema_enem_semantica,
                              checar_tema_enem_por_llm)
@@ -105,7 +105,7 @@ def gerar_resumo_e_tema(noticias):
     texto_noticias = " ".join([noticia["descricao"] for noticia in noticias])
     prompt = build_prompt(texto_noticias)
     contexto = "Você é gerador de temas de redação no Formato ENEM"
-    response = make_llm_call(PROVIDER, MODEL1, contexto, prompt)
+    response = make_llm_call(PROVIDER, MODEL1, contexto, prompt, PROVIDER_API_KEY)
     tema_sugerido = json.loads(response)
 
     # Abordagem de validação do tema por três camadas.

--- a/core/servico_llm.py
+++ b/core/servico_llm.py
@@ -7,31 +7,19 @@ import os
 
 from openai import OpenAI
 
-OPENAI_CLIENT = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+from core.chat_api import ChatAPI
+
 logging.basicConfig(level=logging.INFO)
 
 logger = logging.getLogger(__name__)
 
 
-def make_llm_call(provider, model, contexto, prompt):
-    """
-    Criar uma chamada para o modelo de linguagem.
-    Cria uma camada de abstração para a chamada do modelo de linguagem.
-    Args:
-        provider (str): Provedor do modelo
-        model (str): Modelo
-        contexto (str): Contexto
-        prompt (str): Prompt
-    Returns:
-        response: Resposta do modelo
-    """
-    if provider == "openai":
-        response = make_openai_call(contexto, prompt, model)
-        return response
-    raise ValueError("Provedor não suportado.")
-
+def make_llm_call(provider, model, contexto, prompt, api_key=""):
+    llm = ChatAPI(provider, model, api_key)
+    return llm.gera_conteudo(contexto, prompt)
 
 def make_openai_call(contexto, prompt, model_choice="gpt-4o-mini"):
+    OPENAI_CLIENT = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     """
     Faz a chamada para o modelo OpenAI.
     Arsgs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ feedparser==6.0.11
 openai==1.59.6
 uvicorn==0.32.0
 sentence-transformers==3.4.1
+python-decouple


### PR DESCRIPTION
## Feats 🚀
Adicionei a classe `ChatAPI` que permite um suporte a alguns provedores de LLM diretamente via api rest, como
- OpenAI
- Google Gemini
- DeepSeek

## Refact 🔧
Também refatorei alguns arquivos para remover constantes raw-string permitindo que o LLM e o modelo pudessem ser modificados com facilidade através de um arquivo .env ou variáveis de ambiente.
Variáveis para parametrização do LLM e o modelo:
- PROVIDER: provedor de LLM
- MODEL1: Modelo 1, utilizado para processar a maior massa de tokens
- MODEL2: utilzado para resumir o processamento do MODEL1 e gerar a saída no formato JSON
- PROVIDER_API_KEY: chave de api para consumir os endpoints REST

exemplo com o arquivo `.env`:
```sh
PROVIDER=deepseek
MODEL1=deepseek-chat
MODEL2=deepseek-chat
PROVIDER_API_KEY=sk-12345abcde5432
```
## Chore 🔧
Também modifiquei o `.gitignore` e o `requirements.txt` de acordo com a necessidade!

## 🍻🍻
Foi um uso bem divertido do meu tempo livre hoje =D
Espero que minhas contribuições sejam positivas ao projeto e espero poder contribuir mais!